### PR TITLE
Add dexscraper to Data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Projects related to on-chain data
 | Xray                   | [Helius](https://twitter.com/heliuslabs)                                            | Yes                  | <a href="https://github.com/helius-labs/xray" target="_blank">View</a>                     |
 | Explorer Kit           | [SolanaFM](https://twitter.com/solanafm)                                            | Yes                  | <a href="https://github.com/solana-fm/explorer-kit" target="_blank">View</a>               |
 | SOL CLI Explorer       | [cavemanloverboy](https://github.com/cavemanloverboy)                               | Yes                  | <a href="https://github.com/cavemanloverboy/sol" target="_blank">View</a>                  |
+| Dexscraper             | [Vincent Koc](https://github.com/vincentkoc)                                         | Yes                  | <a href="https://github.com/vincentkoc/dexscraper" target="_blank">View</a>                |
 
 <br>
 


### PR DESCRIPTION
Adds [dexscraper](https://github.com/vincentkoc/dexscraper) under the Data section as an actively maintained Python SDK/CLI for extracting DexScreener market data, including Solana pairs.