### PR TITLE
Add wRTC (Wrapped RustChain Token) to Token & NFT Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Projects related to SPL, Token 2022, and the various NFT standards
 | McBurnJS              | A Node.js CLI to burn even the most stubborn of cNFTs | [McDegensDAO](https://twitter.com/McDegensDAO)                                      | Yes                  | <a href="https://github.com/McDegens-DAO/mcburn-js/" target="_blank">View</a>              |
 | cNFT Spam Filter     | An open-source, lightweight, and portable spam classifier for cNFTs on Solana  | [Solarnius](https://twitter.com/solarnius)                                          | Yes                  | <a href="https://github.com/filtoor/cnft-spam-filter" target="_blank">View</a>             |
 | Underdog SDK          | Mint, Manage, and Distribute Core NFTs , Blinks, or SPL Tokens with No-code on Solana | [Underdog](https://twitter.com/backanunderdog)                                      | No                   | <a href="https://github.com/UnderdogProtocol/js" target="_blank">View</a>                  |
+| wRTC (Wrapped RustChain) | Wrapped RustChain Token bridging Proof-of-Antiquity mining rewards to Solana | [Elyan Labs](https://github.com/Scottcjn)                                           | Yes                  | <a href="https://github.com/Scottcjn/Rustchain" target="_blank">View</a>                   |
 
 <br>
 


### PR DESCRIPTION
## Summary

- Adds **wRTC (Wrapped RustChain Token)** to the Token & NFT Tooling section
- wRTC is an SPL token bridged from RustChain's Proof of Antiquity blockchain
- Tradeable on Raydium (pool `8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb`)
- Mint: `12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X`
- Total supply: 8.3M wRTC, **mint authority revoked**, **metadata immutable**
- Bridge UI: https://bottube.ai/bridge
- Licensed under open source (GitHub: https://github.com/Scottcjn/Rustchain)

## Why it fits this list

wRTC is an actively maintained open-source Solana SPL token project with a working Raydium DEX pool, a live bridge application, and irrevocably locked token parameters (mint revoked, metadata immutable). The RustChain codebase powering it is fully open source on GitHub.