### PR TITLE
Add wRTC Bridge to DeFi section

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Projects related to financial products on Solana
 | Saber                  | [Saber DAO](https://twitter.com/The_Saber_DAO)                                      | Yes                  | <a href="https://github.com/saber-hq/stable-swap" target="_blank">View</a>                  |
 | Step Reward Pool       | [Step Finance](https://twitter.com/StepFinance_)                                    | Yes                  | <a href="https://github.com/step-finance/step-staking" target="_blank">View</a>             |
 | Step Staking           | [Step Finance](https://twitter.com/StepFinance_)                                    | No                   | <a href="https://github.com/step-finance/reward-pool" target="_blank">View</a>              |
+| wRTC Bridge            | [Elyan Labs](https://rustchain.org)                                                 | Yes                  | <a href="https://github.com/Scottcjn/Rustchain" target="_blank">View</a>                    |
 
 <br>
 


### PR DESCRIPTION
## Summary

- Adds **wRTC Bridge** ([Elyan Labs](https://rustchain.org)) to the DeFi section
- wRTC (Wrapped RustChain Token) is a Solana SPL token bridged from the RustChain Proof-of-Antiquity network
- Token mint: `12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X`
- Raydium Pool: `8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb`
- Bridge UI: https://bottube.ai/bridge
- Mint authority **revoked**, LP tokens **permanently locked**, metadata **immutable**
- Repository: https://github.com/Scottcjn/Rustchain (Apache 2.0 license)
- Actively maintained

## Checklist

- [x] Repository has a valid open-source license (Apache 2.0)
- [x] Project is actively maintained
- [x] Entry follows existing table format
- [x] Added to appropriate section (DeFi)

🤖 Generated with [Claude Code](https://claude.com/claude-code)