### PR TITLE
Add readtheskill

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,4 @@ Projects that lack a specific category listed above
 | Jinbag                 | [shockz09](https://github.com/shockz09)                                             | Yes                  | <a href="https://github.com/shockz09/Jinbag" target="_blank">View</a>        |
 | marketplace contracts  | [SoundworkSounds](https://x.com/SoundworkSounds/)                                   | Yes                  | <a href="https://github.com/SoundWorkLabs/marketplace-contracts" target="_blank">View</a> |
 | Solana Auth            | [Crossmint](https://twitter.com/crossmint)                                          | No                   | <a href="https://github.com/Crossmint/solana-auth" target="_blank">View</a>  |
+| readtheskill           | [readtheskill](https://x.com/readtheskill)                                          | Yes                  | <a href="https://github.com/readtheskill/readtheskill" target="_blank">View</a> |


### PR DESCRIPTION
Adds [readtheskill](https://github.com/readtheskill/readtheskill) to Miscellaneous section.

Open-source AI agent skill propagation experiment on Solana with live discovery tracking dashboard at [readtheskill.com](https://readtheskill.com).