### PR TITLE
Add SwarmX to Payments — x402 micropayments on Solana

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Projects related to payment processing for various use-cases
 | Code Program Library   | A collection of on-chain programs targeting the Solana Sealevel runtime | [GetCode](https://twitter.com/getcode)                                              | Yes                  | <a href="https://github.com/code-payments/code-program-library" target="_blank">View</a>   |
 | Code Android App      | A mobile wallet app leveraging self-custodial blockchain technology to deliver an instant, global, and private payments experience | [GetCode](https://twitter.com/getcode)                                              | Yes                  | <a href="https://github.com/code-payments/code-android-app" target="_blank">View</a>       |
 | Stockpile v2           | Decentralized funding engine for the open-internet | [Joey Meere](https://twitter.com/joeymeere)                                         | Yes                  | <a href="https://github.com/StockpileLabs/stockpile-v2" target="_blank">View</a>           |
+| SwarmX (eliza-x402-swarms) | Multi-agent AI orchestration with x402 micropayments. 47 endpoints for contract audits, DeFi risk scoring, code audits, research reports. Pay per call with USDC. | [ItachiDevv](https://github.com/ItachiDevv)                                         | Yes                  | <a href="https://github.com/ItachiDevv/eliza-x402-swarms" target="_blank">View</a>         |
 
 <br>
 


### PR DESCRIPTION
## Summary

Adding **SwarmX** to the Payments section.

SwarmX is an open-source (MIT) platform for AI agent tasks with x402 micropayments on Solana:
- **47 HTTP endpoints** — contract audits, DeFi risk scoring, code audits, research reports, compliance
- **x402 micropayments** — pay per call with USDC ($0.001-$5) on Solana mainnet
- **39 MCP tools**, **15+ swarm architectures**
- First real x402 payment on Solana mainnet completed
- Also supports EVM chains
- ElizaOS v2 plugin + standalone server

GitHub: https://github.com/ItachiDevv/eliza-x402-swarms
License: MIT