### PR TITLE
Add DexPaprika to Data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Projects related to on-chain data
 | Xray                   | A human-readable Solana transaction explorer powered by Helius | [Helius](https://twitter.com/heliuslabs)                                            | Yes                  | <a href="https://github.com/helius-labs/xray" target="_blank">View</a>                     |
 | Explorer Kit           | Public Solana Data Parser | [SolanaFM](https://twitter.com/solanafm)                                            | Yes                  | <a href="https://github.com/solana-fm/explorer-kit" target="_blank">View</a>               |
 | SOL CLI Explorer       | A command line explorer for the Solana Blockchain | [cavemanloverboy](https://github.com/cavemanloverboy)                               | Yes                  | <a href="https://github.com/cavemanloverboy/sol" target="_blank">View</a>                  |
+| DexPaprika             | Free DEX data API with Solana support. Pools, tokens, OHLCV, trades, real-time SSE streaming across 34 chains | [CoinPaprika](https://twitter.com/coinpaprika)                                      | Yes                  | <a href="https://github.com/coinpaprika/dexpaprika-mcp" target="_blank">View</a>           |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Projects related to on-chain data
 | Xray                   | A human-readable Solana transaction explorer powered by Helius | [Helius](https://twitter.com/heliuslabs)                                            | Yes                  | <a href="https://github.com/helius-labs/xray" target="_blank">View</a>                     |
 | Explorer Kit           | Public Solana Data Parser | [SolanaFM](https://twitter.com/solanafm)                                            | Yes                  | <a href="https://github.com/solana-fm/explorer-kit" target="_blank">View</a>               |
 | SOL CLI Explorer       | A command line explorer for the Solana Blockchain | [cavemanloverboy](https://github.com/cavemanloverboy)                               | Yes                  | <a href="https://github.com/cavemanloverboy/sol" target="_blank">View</a>                  |
-| DexPaprika             | Free DEX data API with Solana support. Pools, tokens, OHLCV, trades, real-time SSE streaming across 34 chains | [CoinPaprika](https://twitter.com/coinpaprika)                                      | Yes                  | <a href="https://github.com/coinpaprika/dexpaprika-mcp" target="_blank">View</a>           |
+| DexPaprika             | Free-tier DEX data API with Solana support. Pools, tokens, OHLCV, trades and SSE streaming across 36 chains | [CoinPaprika](https://twitter.com/coinpaprika)                                      | Yes                  | <a href="https://github.com/coinpaprika/dexpaprika-mcp" target="_blank">View</a>           |
 
 <br>
 


### PR DESCRIPTION
Adds DexPaprika to the Data section: pools, tokens, OHLCV, trades and SSE streaming, with Solana as a first-class network, across 36 chains total.

The free tier is keyless to start and metered, streaming included, where one stream update counts as one request. Current quota: https://dexpaprika.com/api/pricing

The repo linked in the row is the MCP server, which is the open-source piece and what most agent setups actually install. Built and run by CoinPaprika, operating since 2018.
