### PR TITLE
Add SwarmX to Payments — x402 micropayments on Solana

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Projects related to payment processing for various use-cases
 | Code Program Library   | A collection of on-chain programs targeting the Solana Sealevel runtime | [GetCode](https://twitter.com/getcode)                                              | Yes                  | <a href="https://github.com/code-payments/code-program-library" target="_blank">View</a>   |
 | Code Android App      | A mobile wallet app leveraging self-custodial blockchain technology to deliver an instant, global, and private payments experience | [GetCode](https://twitter.com/getcode)                                              | Yes                  | <a href="https://github.com/code-payments/code-android-app" target="_blank">View</a>       |
 | Stockpile v2           | Decentralized funding engine for the open-internet | [Joey Meere](https://twitter.com/joeymeere)                                         | Yes                  | <a href="https://github.com/StockpileLabs/stockpile-v2" target="_blank">View</a>           |
+| SwarmX (swarms-x402) | Multi-agent AI orchestration with native x402 micropayments on Solana. 49 endpoints, 39 MCP tools, dual LLM, knowledge/RAG | [SolTwizzy](https://github.com/SolTwizzy)                                         | Yes                  | <a href="https://github.com/SolTwizzy/swarms-x402" target="_blank">View</a>         |
 
 <br>
 


### PR DESCRIPTION
## SwarmX (swarms-x402)

Multi-agent AI orchestration with native x402 micropayments on Solana.

- **49 x402-gated endpoints** on Solana mainnet
- **39 MCP tools** for agent-to-agent discovery
- **Knowledge/RAG**: pgvector semantic search on past analyses
- **Dual LLM**: Gemini 2.5 Flash + OpenAI GPT-4o
- **776 tests**, deployed at https://swarmx.io
- **npm**: swarms-x402

GitHub: https://github.com/SolTwizzy/swarms-x402
Live: https://swarmx.io
Catalog: https://swarmx.io/x402/catalog
MCP: https://swarmx.io/mcp-manifest.json