### PR TITLE
Add Settled Resolver — open-source resolver daemon for Solana prediction markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Projects related to financial products on Solana
 | Step Reward Pool       | Program for staking and receiving rewards| [Step Finance](https://twitter.com/StepFinance_)                                    | Yes                  | <a href="https://github.com/step-finance/step-staking" target="_blank">View</a>             |
 | Step Staking        |  Program for single token staking and receiving rewards   | [Step Finance](https://twitter.com/StepFinance_)                                    | No                   | <a href="https://github.com/step-finance/reward-pool" target="_blank">View</a>              |
 
+| Settled Resolver        | Open-source resolver daemon for Settled prediction markets — earns 10 bps USDC per market resolved on Solana | [Zirodelta](https://twitter.com/zirodelta)                                          | Yes                  | <a href="https://github.com/Zirodelta/resolver" target="_blank">View</a>                    |
+
 <br>
 
 ## 🛠️ Infrastructure


### PR DESCRIPTION
## Adding Settled Resolver to the DeFi section

**Repo:** https://github.com/Zirodelta/resolver  
**Project:** https://www.settled.pro  
**Team:** [@zirodelta](https://twitter.com/zirodelta)

### What it is

The Settled Resolver is an open-source permissionless daemon (written in Go) that resolves prediction markets for the Settled protocol on Solana. It earns 10 bps (0.1%) of total market volume per successful resolution — first valid submission wins.

Settled runs binary YES/NO prediction markets on crypto funding rates, covering 2,400+ perpetual pairs across Binance, Bybit, Hyperliquid, KuCoin, and Gate. The resolver submits Switchboard oracle proofs on-chain to close each market.

**Tech stack:** Go, Solana, Switchboard oracle, Prometheus metrics  
**License:** Apache-2.0  
**Actively maintained:** Yes