### PR TITLE
Add Trade Router MCP to DeFi

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Projects related to financial products on Solana
 | Saber                  | An automated market maker for mean-reverting trading pairs | [Saber DAO](https://twitter.com/The_Saber_DAO)                                      | Yes                  | <a href="https://github.com/saber-hq/stable-swap" target="_blank">View</a>                  |
 | Step Reward Pool       | Program for staking and receiving rewards| [Step Finance](https://twitter.com/StepFinance_)                                    | Yes                  | <a href="https://github.com/step-finance/step-staking" target="_blank">View</a>             |
 | Step Staking        |  Program for single token staking and receiving rewards   | [Step Finance](https://twitter.com/StepFinance_)                                    | No                   | <a href="https://github.com/step-finance/reward-pool" target="_blank">View</a>              |
+| Trade Router MCP       | Non-custodial Solana swap & limit-order MCP server for AI agents. 21 tools across Raydium, PumpSwap, Orca, Meteora. Jito MEV-protected. | [Trade Router](https://twitter.com/trade_router)                                    | Yes                  | <a href="https://github.com/TradeRouter/trade-router-mcp" target="_blank">View</a>             |
 
 <br>
 


### PR DESCRIPTION
Adds **Trade Router MCP** to the DeFi section.

## What it is

[`@traderouter/trade-router-mcp`](https://github.com/TradeRouter/trade-router-mcp) is a non-custodial Solana swap & limit-order MCP server for AI agents. Open-source (MIT), single-file (~85 KB `.mjs`).

- **21 tools**: swap, limit, trailing, TWAP, DCA, and 4 combo orders (limit+TWAP, trailing+TWAP, limit+trailing, limit+trailing+TWAP)
- **Multi-DEX routing**: Raydium, PumpSwap, Orca, Meteora
- **MEV-protected** via Jito bundles (`/protect`)
- **Ed25519 server-message verification** (trust anchor baked in)
- **Private key never leaves the agent** — read once from `TRADEROUTER_PRIVATE_KEY`, signs locally with `@solana/web3.js` + `tweetnacl`

## Install

```bash
npx -y @traderouter/trade-router-mcp
```

Also published to PyPI as `traderouter-mcp` and to the official MCP Registry as `ai.traderouter/trade-router-mcp@1.0.12` (`isLatest: true`).

## Trust signals

- VirusTotal 0/62 on the published `@traderouter/trade-router-mcp@1.0.12` tarball
- CI green on Node 18/20/22 with tarball-leak guard
- Branch protection on `main` (no force-push, required status checks)
- Signed npm publishes (`dist.signatures` on every release)
- Glama listing at <https://glama.ai/mcp/servers/@traderouter/trade-router-mcp> (author-verified)
- 1000+ real production trades

## Why DeFi section

Trade Router is a non-custodial Solana DeFi routing layer. It complements existing DeFi entries (Drift v2, Mango v4, Raydium, Whirlpools/Orca) by providing the agent-facing routing/order-management API rather than being one of the DEXes itself.

Format follows the existing table (Name | Description | Team/Dev | Actively Maintained? | Link). Single-row addition right after `Step Staking`.