### PR TITLE
Add Paraloom to Infrastructure — open privacy Layer 2 for Solana

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Projects related to general infrastructure
 | Jito Relayer           | Jito Foundation's Transaction Relayer | [Jito Labs](https://twitter.com/jito_sol)                                           | Yes                  | <a href="https://github.com/jito-foundation/jito-relayer" target="_blank">View</a>             |
 | Spiral Safe       | Seamless Multichain API Key Management with Nitro Enclave Security     | [Spiral Safe](https://twitter.com/spiralsafe)                                       | Yes                  | <a href="https://github.com/Spiral-Safe" target="_blank">View</a>                              |
 | Space Wrapper         | Secret wrapper program to use from space | [Space Operator](https://twitter.com/_space_operator)                               | No                   | <a href="https://github.com/space-operator/space-wrapper" target="_blank">View</a>             |
+| Paraloom              | Open privacy Layer 2 for Solana — shielded payments via Groth16 zk-SNARKs over BLS12-381, BFT cohort verification on commodity hardware | [Paraloom Labs](https://x.com/paraloomlabs)                                         | Yes                  | <a href="https://github.com/paraloom-labs/paraloom-core" target="_blank">View</a>              |
 
 <br>
 


### PR DESCRIPTION
Adding [Paraloom](https://github.com/paraloom-labs/paraloom-core) to **Infrastructure** alongside Light Protocol and Elusiv (other Solana privacy infrastructure).

### What it is
An open privacy Layer 2 for Solana. SOL bridges into a shielded pool through an Anchor program; transfers move privately under Groth16 zk-SNARKs over BLS12-381; a small BFT validator cohort verifies each proof in roughly 10 ms on commodity hardware. State that matters — merkle root, nullifier PDAs, validator stake, slashing record — is anchored on Solana.

### Open-source criteria
- **License:** MIT
- **Repo:** https://github.com/paraloom-labs/paraloom-core
- **Lines of Rust:** ~33,000
- **Tests:** 407 passing
- **Active maintenance:** Yes — current release v0.5.0-rc2, multi-platform signed binaries via Sigstore keyless flow, CycloneDX SBOM
- **Documentation:** https://docs.paraloom.io
- **Status:** Pre-mainnet (gated on MPC ceremony execution + external audit). No token.

### Site
https://paraloom.io