### PR TITLE
Add SafePump-Core to DeFi section

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Projects related to financial products on Solana
 | Saber                  | An automated market maker for mean-reverting trading pairs | [Saber DAO](https://twitter.com/The_Saber_DAO)                                      | Yes                  | <a href="https://github.com/saber-hq/stable-swap" target="_blank">View</a>                  |
 | Step Reward Pool       | Program for staking and receiving rewards| [Step Finance](https://twitter.com/StepFinance_)                                    | Yes                  | <a href="https://github.com/step-finance/step-staking" target="_blank">View</a>             |
 | Step Staking        |  Program for single token staking and receiving rewards   | [Step Finance](https://twitter.com/StepFinance_)                                    | No                   | <a href="https://github.com/step-finance/reward-pool" target="_blank">View</a>              |
+| SafePump-Core          | Anti-MEV bonding curve launchpad primitive with first-slot snipe vesting and compound penalty (Anchor/Rust) | [Nosferatus](https://github.com/Nosferatus1988)                                     | Yes                  | <a href="https://github.com/Nosferatus1988/SafePump-Core" target="_blank">View</a>          |
 
 <br>
 


### PR DESCRIPTION
Adds **SafePump-Core**, an open-source Anchor program implementing an anti-MEV bonding curve primitive for Solana token launches.

## What it does
Detects buys within the first ~10 slots of a token mint and routes them into a per-buyer vesting vault locked for 48 hours. Every additional snipe by the same wallet resets the 48-hour timer, creating a compound penalty for repeat sniping. Normal buys after the snipe window go straight to the buyer wallet.

This is application-layer MEV protection, complementary to validator-layer approaches like Jito.

## Repo details
- License: MIT
- Language: Rust (Anchor)
- Devnet program: `FMAhGG8ETyqnd4zan4HBdLRPEQvk7Cvc6kzWbsvnXj5q`
- Site: https://www.safepump-core.com
- Status: devnet MVP, accepting contributors
- Topics: solana, anchor, defi, launchpad, mev, bonding-curve, anti-snipe, rust

Placed under `## 💰 DeFi` since it's a DeFi/launchpad primitive. Happy to move if you prefer a different section.

Thanks for maintaining the list!