### PR TITLE
Add OpenChainBench to Data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Projects related to on-chain data
 | Xray                   | A human-readable Solana transaction explorer powered by Helius | [Helius](https://twitter.com/heliuslabs)                                            | Yes                  | <a href="https://github.com/helius-labs/xray" target="_blank">View</a>                     |
 | Explorer Kit           | Public Solana Data Parser | [SolanaFM](https://twitter.com/solanafm)                                            | Yes                  | <a href="https://github.com/solana-fm/explorer-kit" target="_blank">View</a>               |
 | SOL CLI Explorer       | A command line explorer for the Solana Blockchain | [cavemanloverboy](https://github.com/cavemanloverboy)                               | Yes                  | <a href="https://github.com/cavemanloverboy/sol" target="_blank">View</a>                  |
+| OpenChainBench         | Live open-source benchmarks for Solana infra: tx-landing services, RPC latency, token metadata coverage | [OpenChainBench](https://x.com/OpenChainBench)                                      | Yes                  | <a href="https://github.com/ChainBench/OpenChainBench" target="_blank">View</a>            |
 
 <br>
 


### PR DESCRIPTION
Adds [OpenChainBench](https://github.com/ChainBench/OpenChainBench) to the Data section.

OpenChainBench runs live, open-source benchmarks for Solana infrastructure:
- Transaction landing services (Jito, Helius Sender, Nozomi, bloXroute, 0slot...) measured by on-chain tip wallet attribution
- RPC provider latency across regions
- Token metadata coverage on fresh mints (pump.fun, Meteora, Raydium launchpads)

Everything is reproducible: harnesses are open source, metrics served from a public Prometheus, data licensed CC-BY-4.0. Actively maintained (MIT).