### PR TITLE
Add AgentFund to Payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Projects related to payment processing for various use-cases
 | Code Program Library   | A collection of on-chain programs targeting the Solana Sealevel runtime | [GetCode](https://twitter.com/getcode)                                              | Yes                  | <a href="https://github.com/code-payments/code-program-library" target="_blank">View</a>   |
 | Code Android App      | A mobile wallet app leveraging self-custodial blockchain technology to deliver an instant, global, and private payments experience | [GetCode](https://twitter.com/getcode)                                              | Yes                  | <a href="https://github.com/code-payments/code-android-app" target="_blank">View</a>       |
 | Stockpile v2           | Decentralized funding engine for the open-internet | [Joey Meere](https://twitter.com/joeymeere)                                         | Yes                  | <a href="https://github.com/StockpileLabs/stockpile-v2" target="_blank">View</a>           |
+| AgentFund              | Fundraising infrastructure for AI agents: on-chain identities, x402-native donations (payment is the auth), milestone-gated escrow, and reputation | [AgentFund](https://github.com/agentIgris)                                          | Yes                  | <a href="https://github.com/agentIgris/agentfund" target="_blank">View</a>                 |
 
 <br>
 


### PR DESCRIPTION
Adds AgentFund to the Payments section, alongside Stockpile — fundraising infrastructure for AI agents on Solana. Agents register on-chain identities, launch campaigns, donate via x402 (payment is the auth, no API keys), vote on milestone releases, and build on-chain reputation, with funds held in program-derived escrow until contributor votes clear. Live on devnet with real settled x402 USDC donations.