### PR TITLE
Add txplain and mintcheck to Dev Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Projects that will may help in your travels as a Solana developer
 | Splogger            | Solana logging framework   | [Nautilus Project](https://github.com/nautilus-project)                             | No                   | <a href="https://github.com/nautilus-project/splogger" target="_blank">View</a>            |
 | Waverider         | Geyser plugin that streams Solana account changes to PostgREST     | [Nautilus Project](https://github.com/nautilus-project)                             | No                   | <a href="https://github.com/nautilus-project/waverider" target="_blank">View</a>           |
 | Anchor Eventline  | Standardized Anchor events + TypeScript SDK for reliable off-chain indexing.     | Fabrizio Pfannl                                                                     | Yes                  | <a href="https://github.com/fabriziopfannl/anchor-eventline" target="_blank">View</a> |
+| txplain           | Paste a transaction signature, get a plain-English breakdown: status, fee, every balance change, which programs it touched, and why it failed. Static page, public RPC only.     | [Alfred Labs](https://x.com/Alfred_labs)                                            | Yes                  | <a href="https://github.com/arijon13/txplain" target="_blank">View</a> |
+| mintcheck         | Paste an SPL token mint and see the rug-risk flags: whether mint authority can print more supply, and whether freeze authority can freeze your tokens. No wallet, no signup.     | [Alfred Labs](https://x.com/Alfred_labs)                                            | Yes                  | <a href="https://github.com/arijon13/mintcheck" target="_blank">View</a> |
 
 <br>
 


### PR DESCRIPTION
Two small MIT-licensed Solana developer tools from Alfred Labs. Both are static pages that read public RPC in the browser — no wallet connect, no signup, no backend, nothing stored.

**txplain** — paste a transaction signature and get a plain-English breakdown: status, fee, every SOL and token balance change, which programs it touched, and the decoded reason if it failed. Aimed at the moment where a tx fails and the explorer shows you a raw error code.
https://arijon13.github.io/txplain/ · https://github.com/arijon13/txplain

**mintcheck** — paste an SPL token mint and see the rug-risk flags that actually matter before you buy: whether the mint authority can still print supply, and whether the freeze authority can freeze your tokens.
https://arijon13.github.io/mintcheck/ · https://github.com/arijon13/mintcheck

Both are MIT licensed and actively maintained. Happy to move them to a different section, trim the descriptions, or drop either one if they are not a fit for the list.