### PR TITLE
Add solana-postmortem-scans to Security & Reverse Engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Program auditing, fuzzing, static analysis, and more.
 | [Trident](https://github.com/Ackee-Blockchain/trident) | Rust-based framework for Solana program fuzzing |
 | [qedsvm](https://github.com/QEDGen/qedsvm) | Execute and verify sBPF programs with a Lean 4 reference model |
 | [sol-azy](https://github.com/FuzzingLabs/sol-azy) | Tooling for static analysis and reverse engineering sBPF programs |
+| [solana-postmortem-scans](https://github.com/AIOilShield/solana-postmortem-scans) | Automated static-analysis runs on the pre-exploit code of Wormhole and Cashio, with the raw output and a manual review of every finding |
 
 ## Governance
 


### PR DESCRIPTION
Adds one entry to **Security & Reverse Engineering**.

[solana-postmortem-scans](https://github.com/AIOilShield/solana-postmortem-scans) — MIT.

We ran an automated multi-agent static analyser over the pre-exploit source of the Wormhole core bridge (Feb 2022) and of Cashio (Mar 2022), and published both results. On Wormhole it reported the real root cause — the unverified instructions sysvar in `verify_signature.rs` — as Critical, with the right location and the fix that was actually shipped. On Cashio it missed the root cause and flagged a related symptom instead. The repo has the write-up, the console output of both runs, and a table stating which of the reported findings hold up under manual review and which do not (one Critical does not apply to the deployed bridge; one Medium is over-rated).

Two things worth stating up front:

- It is a write-up plus artifacts rather than a tool. If Miscellaneous is a better fit — or if it does not belong here at all — say so and I will move it or close this.
- The scanner that produced the output is a paid service and is not open source. What is being listed is the write-up and the artifacts, which are MIT.

Checklist: valid open-source license (MIT); accurate one-line description; working repository link; not a duplicate; table formatting matches the rest of the list.